### PR TITLE
STY: enable `flake8` checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
This way we capture more potential issues.

Although, the number of flake8 errors is significant, many of them are repeating, such as:
```
...
pyCHX/XPCS_SAXS.py:240:10: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:241:12: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:242:12: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:243:12: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:244:18: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:245:17: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:246:17: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:248:28: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:250:42: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:250:76: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:252:22: F405 'roi' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:253:16: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:254:12: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:256:16: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:258:5: E741 ambiguous variable name 'l'
pyCHX/XPCS_SAXS.py:260:15: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:262:27: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:271:20: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:273:22: F405 'roi' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:274:16: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:275:12: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:276:16: F405 'np' may be undefined, or defined from star imports: pyCHX.chx_generic_functions
pyCHX/XPCS_SAXS.py:277:5: E741 ambiguous variable name 'l'
...
```